### PR TITLE
Add 'parameters:' key in transform_input function for llama2

### DIFF
--- a/kendra_retriever_samples/kendra_chat_llama_2.py
+++ b/kendra_retriever_samples/kendra_chat_llama_2.py
@@ -35,7 +35,7 @@ def build_chain():
                                     #{"role": "system", "content": ""},
                                     {"role": "user", "content": prompt},
                                   ]],
-                                  **model_kwargs
+                                  "parameters": {**model_kwargs}
                                   })
           print(input_str)
           return input_str.encode('utf-8')


### PR DESCRIPTION
I deployed this sample with a meta-textgeneration-llama-2-7b-f endpoint generated from Jumpstart and was getting this error from endpoint due to incorrectly formatted input:
```
ValueError: Error raised by inference endpoint: An error occurred (ModelError) when calling the InvokeEndpoint operation: Received client error (424) from primary with message "{
  "code":424,
  "message":"prediction failure",
  "error":"Input payload must contain a 'inputs' key and optionally a 'parameters' key containing a dictionary of parameters."
```
This change adds a 'parameters:' key to the model_kwargs value and corrects the error.